### PR TITLE
Remove invalid namespace for sync

### DIFF
--- a/fh-sync-js.d.ts
+++ b/fh-sync-js.d.ts
@@ -4,13 +4,6 @@
 
 /** @module SyncClient */
 declare module SyncClient {
-    /**
-     * Sync namespace
-     * 
-     * @namespace Sync
-     */
-    export namespace Sync {
-
         /**
          * Interface for the data provided in the NotifyCallback in the notify function.
          * 
@@ -322,7 +315,6 @@ declare module SyncClient {
          * @param handler - function that wraps underlying storage solution
          */
         function setStorageAdapter(handler: (dataset_id:string, isSave: boolean, cb: any) => void);
-    }
 }
 
 export = SyncClient;


### PR DESCRIPTION
## Motivation

Remove unused namespace from client to simplify imports in TypeScript.

Note: This change has no side effect on fh-js-sdk as it has separate type definitions. 

ping @paolobueno 