### PR TITLE
 ✨  resend pending changes that could be stuck on the client

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
   //run tests in phatomjs
   grunt.registerTask('test', ['jshint:all', 'browserify:dist', 'browserify:require', 'browserify:test', 'connect:server', 'mocha_phantomjs:test']);
 
-    grunt.registerTask('concat-core-sdk', ['jshint',  'concat:lawnchair', 'concat:crypto', 'browserify:dist']);
+  grunt.registerTask('concat-core-sdk', ['jshint',  'concat:lawnchair', 'concat:crypto', 'browserify:dist']);
 
 
   grunt.registerTask('default', ['jshint', 'concat-core-sdk', 'test','uglify:dist']);

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/feedhenry/fh-sync-js",
   "authors": [
     "npm@feedhenry.com"

--- a/fh-sync-js.d.ts
+++ b/fh-sync-js.d.ts
@@ -139,7 +139,15 @@ declare module SyncClient {
     /**
      * iOS only. If set to true, the file will be backed by iCloud. Default to false;
      */
-    icloud_backup?: boolean
+    icloud_backup?: boolean,
+
+    /* 
+     * If set, the client will resend the pending changes that are inflight, but haven't crashed, and have lived longer than this value.
+     * This is to prevent the situation where updates are lost for certain pending changes, those pending changes will be stuck on the client forever.
+     * Default value is 24 hours.
+     * Optional. Default: 60*24
+     */
+    resend_inflight_pendings_minutes?: number
   }
 
   /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Javascript client for fh-sync offline synchronization library",
   "main": "src/index.js",
   "types": "./fh-sync-js.d.ts",


### PR DESCRIPTION
This PR will make sure the client will resent the inflight pending changes that could be stuck.

## Context

At the moment, when pending changes are submitted, they are marked as `inflight` and the client will not try to resend them unless the submission is failed. The original idea behind that is that once the submission is successful, the server is guaranteed to process the pending changes, and the client should hear back updates about those changes from the server at some point, so there is no need for those pending changes to be submitted again (to avoid unnecessary collisions).

However, in some extreme cases,  the updates could be lost (One scenario we have see for this to happen is when multiple clients are using the same `cuid` by mistake. In this case, the updates that are for client A are removed by Client B). When this happens, Client A will never get the updates about the pending changes, and those pending changes are stuck on the client for ever.  To make things worst, all the following updates on this client are not sent as well, but they are all waiting for the previous inflight pending changes to be resolved first.

## Solution

To resolve this issue, we introduce a retry mechanism. When the sync loop runs, it will check how long an inflight pending change has lived. If the pending change has lived for too long and no updates on it, the client will assume something went wrong and submit the change. If worst thing could happen is that there will be extra collisions generated, but that is much better than the pending change stuck on the client forever.

Ping @wtrocki @aidenkeating for review. 

