### PR TITLE
Make isOnline public

### DIFF
--- a/fh-sync-js.d.ts
+++ b/fh-sync-js.d.ts
@@ -437,9 +437,9 @@ declare module SyncClient {
   /**
    * Allows to override default method for checking if application is online
    *
-   * @param method - function that checks if network is available
+   * @param handlerFunction - function that implements checks for network availability
    */
-  function setNetworkStatusHandler(method: (callback: (isOnline: boolean) => void) => void): void;
+  function setNetworkStatusHandler(handlerFunction: (callback: (isOnline: boolean) => void) => void): void;
 }
 
 export = SyncClient;

--- a/fh-sync-js.d.ts
+++ b/fh-sync-js.d.ts
@@ -426,12 +426,20 @@ declare module SyncClient {
    * @param handler - function that wraps underlying storage solution
    */
   function setStorageAdapter(handler: (dataset_id: string, isSave: boolean, cb: any) => void): void;
+
   /**
    * Allows to override default hashing method
    *
    * @param method - function that wraps underlying hashing method
    */
   function setHashMethod(method: () => any): void;
+
+  /**
+   * Allows to override default method for checking if application is online
+   *
+   * @param method - function that checks if network is available
+   */
+  function setNetworkStatusHandler(method: (callback: (isOnline: boolean) => void) => void): void;
 }
 
 export = SyncClient;

--- a/src/sync-client.js
+++ b/src/sync-client.js
@@ -314,8 +314,10 @@ var self = {
     });
   },
 
-
-  // PRIVATE FUNCTIONS
+  /**
+   * Check if client is online. 
+   * Function is used to stop sync from executing requests.
+   */
   isOnline: function(callback) {
     var online = true;
 
@@ -338,6 +340,7 @@ var self = {
     return callback(online);
   },
 
+  // PRIVATE FUNCTIONS
   doNotify: function(dataset_id, uid, code, message) {
 
     if( self.notify_callback || self.notify_callback_map[dataset_id]) {
@@ -1289,5 +1292,6 @@ module.exports = {
   setCloudHandler: self.setCloudHandler,
   doCloudCall: self.doCloudCall,
   setStorageAdapter: self.setStorageAdapter,
-  setHashMethod: self.setHashMethod
+  setHashMethod: self.setHashMethod,
+  isOnline : self.isOnline
 };

--- a/src/sync-client.js
+++ b/src/sync-client.js
@@ -315,6 +315,16 @@ var self = {
   },
 
   /**
+   * Allows to override default method for checking if application is online
+   *
+   * @param handler - function that checks if network is available
+   */
+  setNetworkStatusHandler: function(handler){
+    self.isOnline = handler;
+  },
+  
+  // PRIVATE FUNCTIONS
+  /**
    * Check if client is online. 
    * Function is used to stop sync from executing requests.
    */
@@ -340,7 +350,6 @@ var self = {
     return callback(online);
   },
 
-  // PRIVATE FUNCTIONS
   doNotify: function(dataset_id, uid, code, message) {
 
     if( self.notify_callback || self.notify_callback_map[dataset_id]) {
@@ -1293,5 +1302,5 @@ module.exports = {
   doCloudCall: self.doCloudCall,
   setStorageAdapter: self.setStorageAdapter,
   setHashMethod: self.setHashMethod,
-  isOnline : self.isOnline
+  setNetworkStatusHandler : self.setNetworkStatusHandler
 };

--- a/src/sync-client.js
+++ b/src/sync-client.js
@@ -317,10 +317,14 @@ var self = {
   /**
    * Allows to override default method for checking if application is online
    *
-   * @param handler - function that checks if network is available
+   * @param handlerFunction - function that checks if network is available
    */
-  setNetworkStatusHandler: function(handler){
-    self.isOnline = handler;
+  setNetworkStatusHandler: function(handlerFunction){
+    if (handler && typeof handler === "function") {
+      self.isOnline = handler;
+    } else {
+      self.consoleLog("setNetworkStatusHandler called  with wrong parameter");
+    }
   },
   
   // PRIVATE FUNCTIONS
@@ -916,8 +920,12 @@ var self = {
    * Sets cloud handler for sync responsible for making network requests:
    * For example function(params, success, failure)
    */
-  setCloudHandler: function(cloudHandler){
-    self.cloudHandler = cloudHandler;
+  setCloudHandler: function(cloudHandler) {
+    if (cloudHandler && typeof cloudHandler === "function") {
+      self.cloudHandler = cloudHandler;
+    } else {
+      self.consoleLog("setCloudHandler called  with wrong parameter");
+    }
   },
 
   doCloudCall: function(params, success, failure) {
@@ -943,8 +951,12 @@ var self = {
   },
 
   /** Allow to set custom hasing method **/
-  setHashMethod: function(method){
-    self.getHashMethod = method;
+  setHashMethod: function(method) {
+    if (method && typeof method === "function") {
+      self.getHashMethod = method;
+    } else {
+      self.consoleLog("setHashMethod called  with wrong parameter");
+    }
   },
   
   getStorageAdapter: function(dataset_id, isSave, cb){
@@ -1298,8 +1310,8 @@ module.exports = {
   generateHash: self.generateHash,
   loadDataSet: self.loadDataSet,
   clearCache: self.clearCache,
-  setCloudHandler: self.setCloudHandler,
   doCloudCall: self.doCloudCall,
+  setCloudHandler: self.setCloudHandler,
   setStorageAdapter: self.setStorageAdapter,
   setHashMethod: self.setHashMethod,
   setNetworkStatusHandler : self.setNetworkStatusHandler


### PR DESCRIPTION
## Motivation

Expose `isOnline` function. Function can be swapped by clients who want to use some custom cordova plugin etc. 

## Typical use case

When running on different environments (like React native) users may provide different method or even decide to always return true. 