### PR TITLE
#30 Use clientid outside handler

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Javascript client for fh-sync offline synchronization library",
   "main": "src/index.js",
   "types": "./fh-sync-js.d.ts",

--- a/src/cloudHandler.js
+++ b/src/cloudHandler.js
@@ -1,6 +1,5 @@
 var cloudURL;
 var cloudPath;
-var cidProvider = require('./clientIdProvider');
 
 /**
  * Default sync cloud handler responsible for making all sync requests to 
@@ -13,9 +12,6 @@ var handler = function (params, success, failure) {
     }
     var url = cloudURL + cloudPath + params.dataset_id;
     var payload = params.req;
-    payload.__fh = {
-        cuid: cidProvider.getClientId()
-    };
     var json = JSON.stringify(payload);
     var xhr = new XMLHttpRequest();
     xhr.open("POST", url, true);

--- a/src/sync-client.js
+++ b/src/sync-client.js
@@ -1,6 +1,7 @@
 var CryptoJS = require("../libs/generated/crypto");
 var Lawnchair = require('../libs/generated/lawnchair');
 var defaultCloudHandler = require('./cloudHandler');
+var cidProvider = require('./clientIdProvider');
 
 var MILLISECONDS_IN_MINUTE = 60*1000;
 
@@ -910,6 +911,11 @@ var self = {
 
   doCloudCall: function(params, success, failure) {
     if(self.cloudHandler && typeof self.cloudHandler === "function" ){
+      if (params && params.req) {
+        params.req.__fh = {
+          cuid: cidProvider.getClientId()
+        };
+      }
       self.cloudHandler(params, success, failure);
     } else {
       console.log("Missing cloud handler for sync. Please refer to documentation");


### PR DESCRIPTION
## Motivation

When building custom handlers users will need to also implement client id generator. 
In most of the cases implementation will be the same. 
Logic for generating id should be separated and handler should not require client id implementation to be present. This was suggested by @wei-lee when reviewing original ticket.