### PR TITLE
Add notify function without parameter

### DIFF
--- a/fh-sync-js.d.ts
+++ b/fh-sync-js.d.ts
@@ -189,11 +189,19 @@ declare module SyncClient {
 
   /**
    * Register a callback function to be invoked when the sync service has notifications to communicate to the client.
-   * 
-   * @param dataset_id - dataset identifier
+   *
+   * @param dataset_id - id of dataset to recieve notifications
    * @param {Function} callback
    */
   function notify(dataset_id: string, callback: NotifyCallback): void;
+
+  /**
+   * Register a callback function to be invoked when the sync service has notifications to communicate to the client.
+   *
+   * @param {Function} callback
+   */
+  function notify(callback: NotifyCallback): void;
+
   /**
    * Put a dataset under the management of the sync service.
    *


### PR DESCRIPTION
Updating TypeScript definitions for notify function.
Users should be able to use both variations if needed.

Code uses single function to remove parameter: 
https://github.com/feedhenry/fh-sync-js/blob/8ff4d4374ae51b8118587dba61cd9e936ba5c56d/src/sync-client.js#L114-L120