### PR TITLE
Add create cloud handler helper function

### DIFF
--- a/fh-sync-js.d.ts
+++ b/fh-sync-js.d.ts
@@ -141,13 +141,33 @@ declare module SyncClient {
      */
     icloud_backup?: boolean,
 
-    /* 
+    /*
      * If set, the client will resend the pending changes that are inflight, but haven't crashed, and have lived longer than this value.
      * This is to prevent the situation where updates are lost for certain pending changes, those pending changes will be stuck on the client forever.
      * Default value is 24 hours.
      * Optional. Default: 60*24
      */
     resend_inflight_pendings_minutes?: number
+  }
+
+  /**
+   * Interface for a header option in CloudHandlerOptions
+   *
+   * @interface CloudHandlerHeader
+   */
+  interface CloudHandlerHeader {
+    name: string,
+    value: string
+  }
+
+  /**
+   * Interface for the options provided to createCloudHandler
+   *
+   * @interface CloudHandlerOptions
+   */
+  interface CloudHandlerOptions {
+    cloudPath?: string,
+    headers?: CloudHandlerHeader[]
   }
 
   /**
@@ -183,7 +203,7 @@ declare module SyncClient {
    * @param {Boolean} [options.sync_active=true] - Is the background synchronization with the cloud currently active. If this is set to false, the synchronization loop will not start automatically. You need to call startSync to start the synchronization loop.
    * @param {String} [options.storage_strategy=html5_filesystem] - Storage strategy to use for the underlying client storage framework Lawnchair. Valid values include 'dom', 'html5-filesystem', 'webkit-sqlite', 'indexed-db'. Multiple values can be specified as an array and the first valid storage option will be used. If the app is running on Titanium, the only support value is 'titanium'.
    * @param {Number} [options.file_system_quota=52428800] - Amount of space to request from the HTML5 filesystem API when running in browser
-   * @param {Boolean} [options.icloud_backup=false] - iOS only. If set to true, the file will be backed by iCloud. 
+   * @param {Boolean} [options.icloud_backup=false] - iOS only. If set to true, the file will be backed by iCloud.
    */
   function init(options: SyncOptions): void;
 
@@ -423,10 +443,22 @@ declare module SyncClient {
 
   /**
    * Sets cloud call handler for sync. Required to make any sync requests to the server side (sync cloud)
-   * 
+   *
    * @param {Function} handler - method responsible for handling network requests
    */
   function setCloudHandler(handler: (params: any, success: (result: any) => void, failure: (error: any) => void) => void): void;
+
+  /**
+   * Create a cloud handler to be used with setCloudHandler().
+   *
+   * @param {string} baseUrl Url of the server without any paths, e.g https://feedhenry.com
+   * @param {Object} options
+   * @param {Object[]} options.headers List of headers to append to each request
+   * @param {string} options.headers.name Name of header, e.g. Content-Type
+   * @param {string} options.headers.value Value of header, e.g. application/json
+   * @param {string} options.cloudPath Path to append to baseUrl
+   */
+  function createCloudHandler(baseUrl: string, options: CloudHandlerOptions): void;
 
   /**
    * Allows to override default storage adapter

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "loglevel": "~0.6.0",
     "process": "~0.6.0",
+    "request": "^2.81.0",
     "type-of": "~2.0.1",
     "underscore": "~1.6.0",
     "uuid": "^3.0.1"

--- a/src/cloudHandler/createCloudHandler.js
+++ b/src/cloudHandler/createCloudHandler.js
@@ -1,0 +1,46 @@
+/**
+ * Module for creating a custom cloud handler for sync. This can be used when
+ * a user needs to add custom headers to each sync request, handle successful
+ * and failed sync responses in different ways.
+ */
+
+var _ = require('underscore');
+
+function createCloudHandler(baseUrl, options) {
+
+  // Ensure the properties we use actually exist. This will not overwrite
+  // values, these values will only be used when a value is undefined.
+  options = _.defaults(options, {
+    cloudPath: '/',
+    headers: []
+  });
+
+  return function(params, success, failure) {
+    var url = baseUrl + options.cloudPath + params.dataset_id;
+    var payload = JSON.stringify(params.req);
+    var xhr = new XMLHttpRequest();
+
+    xhr.open('POST', url, true);
+    xhr.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+    _.forEach(options.headers, function(header) {
+      xhr.setRequestHeader(header.name, header.value);
+    });
+
+    xhr.onreadystatechange = function() {
+      if(xhr.readyState === XMLHttpRequest.DONE) {
+        if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304) {
+          try {
+            var responseJson = JSON.parse(xhr.responseText);
+            return success(xhr.responseJson);
+          } catch(e) {
+            return failure(e);
+          }
+        }
+        return failure(xhr.responseText);
+      }
+    };
+    xhr.send(payload);
+  };
+}
+
+module.exports = createCloudHandler;

--- a/src/sync-client.js
+++ b/src/sync-client.js
@@ -2,6 +2,9 @@ var CryptoJS = require("../libs/generated/crypto");
 var Lawnchair = require('../libs/generated/lawnchair');
 var defaultCloudHandler = require('./cloudHandler');
 var cidProvider = require('./clientIdProvider');
+var _ = require("underscore");
+
+var createCloudHandler = require('./cloudHandler/createCloudHandler');
 
 var MILLISECONDS_IN_MINUTE = 60*1000;
 
@@ -30,7 +33,7 @@ var self = {
     "notify_remote_update_applied": true,
     // Should a notification event be triggered when an update was applied to the remote data store
     "notify_delta_received": true,
-    // Should a notification event be triggered when a delta was received from the remote data store for the dataset 
+    // Should a notification event be triggered when a delta was received from the remote data store for the dataset
     "notify_record_delta_received": true,
     // Should a notification event be triggered when a delta was received from the remote data store for a record
     "notify_sync_failed": true,
@@ -72,9 +75,9 @@ var self = {
     "LOCAL_UPDATE_APPLIED": "local_update_applied",
     // An update was applied to the local data store
     "DELTA_RECEIVED": "delta_received",
-    // A delta was received from the remote data store for the dataset 
+    // A delta was received from the remote data store for the dataset
     "RECORD_DELTA_RECEIVED": "record_delta_received",
-    // A delta was received from the remote data store for the record 
+    // A delta was received from the remote data store for the record
     "SYNC_FAILED": "sync_failed"
     // Sync loop failed to complete
   },
@@ -327,10 +330,10 @@ var self = {
       self.consoleLog("setNetworkStatusHandler called  with wrong parameter");
     }
   },
-  
+
   // PRIVATE FUNCTIONS
   /**
-   * Check if client is online. 
+   * Check if client is online.
    * Function is used to stop sync from executing requests.
    */
   isOnline: function(callback) {
@@ -624,7 +627,7 @@ var self = {
 
   syncLoop: function(dataset_id) {
     self.getDataSet(dataset_id, function(dataSet) {
-    
+
       // The sync loop is currently active
       dataSet.syncPending = false;
       dataSet.syncRunning = true;
@@ -762,7 +765,7 @@ var self = {
             self.doNotify(dataset_id, i, self.notifications.RECORD_DELTA_RECEIVED, "create");
           }
         }
-        
+
         if (res.update) {
           for (i in res.update) {
             localDataSet[i].hash = res.update[i].hash;
@@ -950,7 +953,7 @@ var self = {
       self.datasetMonitor();
     }, 500);
   },
-  
+
   /** Allow to set custom storage adapter **/
   setStorageAdapter: function(adapter){
     self.getStorageAdapter = adapter;
@@ -964,7 +967,7 @@ var self = {
       self.consoleLog("setHashMethod called  with wrong parameter");
     }
   },
-  
+
   getStorageAdapter: function(dataset_id, isSave, cb){
     var onFail = function(msg, err){
       var errMsg = (isSave?'save to': 'load from' ) + ' local storage failed msg: ' + msg + ' err: ' + err;
@@ -1230,7 +1233,7 @@ var self = {
           var pendingHash = metadata.pendingUid;
           self.consoleLog("updateMetaFromNewData - Found metadata with uid = " + uid + " :: pendingHash = " + pendingHash);
           var pendingResolved = true;
-  
+
           if(pendingHash){
             //we have current pending in meta data, see if it's resolved
             pendingResolved = false;
@@ -1316,8 +1319,9 @@ module.exports = {
   generateHash: self.generateHash,
   loadDataSet: self.loadDataSet,
   clearCache: self.clearCache,
-  doCloudCall: self.doCloudCall,
+  createCloudHandler: createCloudHandler,
   setCloudHandler: self.setCloudHandler,
+  doCloudCall: self.doCloudCall,
   setStorageAdapter: self.setStorageAdapter,
   setHashMethod: self.setHashMethod,
   setNetworkStatusHandler : self.setNetworkStatusHandler


### PR DESCRIPTION
Currently when specifying a new cloud handler a user has to write
all of the request logic themselves. In some cases, such as wanting
only to append a new header to each request this is quite a lot of
work.

This adds a createCloudHandler function to fh-sync-js that allows
these situations to be handled in a nicer way. The request logic
itself remains in fh-sync-js.