### PR TITLE
Allow to pass cookies in default handler

### DIFF
--- a/src/cloudHandler.js
+++ b/src/cloudHandler.js
@@ -14,6 +14,7 @@ var handler = function (params, success, failure) {
     var payload = params.req;
     var json = JSON.stringify(payload);
     var xhr = new XMLHttpRequest();
+    xhr.withCredentials = true;
     xhr.open("POST", url, true);
     xhr.setRequestHeader('Content-type', 'application/json; charset=utf-8');
     xhr.onreadystatechange = function () {


### PR DESCRIPTION
When making request we should allow cookies (this statement causing no harm and side effects when cookies aren't used and I think for most of the use cases this will simplify authentication processing for sync. Without that users will need to provide default handler that will attach cookie

Proposition for issue: https://github.com/feedhenry/fh-sync-js/issues/36

@JameelB FYI
