### PR TITLE
[task]:RHMAP-20283- Update CI process to use supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-  - "6.11.3"
+  - 4
+  - 6
+  - 8
 before_install:
-  - npm install -g npm@3
+  - npm install -g npm@3.10.8
 install: npm install
 script:
   - npm run ci


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20283

## WHAT
Update NodeJS version to use 4, 6, and 8 as follows.

```
node_js:
  - '4'
  - '6'
  - '8'
```
Update npm version to 3.10.8


## WHY
Use in the CI the currently supported versions.

## Verification Steps:
Check if the all steps in Trevis are finishing with success. 
