### PR TITLE
[WIP] - RHMAP-20023 - doNotifiy to be called after async saveDataSet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Javascript client for fh-sync offline synchronization library",
   "main": "src/index.js",
   "types": "./fh-sync-js.d.ts",

--- a/src/sync-client.js
+++ b/src/sync-client.js
@@ -591,8 +591,9 @@ function newClient(id) {
           if(self.config.auto_sync_local_updates) {
             dataset.syncPending = true;
           }
-          self.saveDataSet(dataset_id);
-          self.doNotify(dataset_id, uid, self.notifications.LOCAL_UPDATE_APPLIED, action);
+          self.saveDataSet(dataset_id, function() {
+            self.doNotify(dataset_id, uid, self.notifications.LOCAL_UPDATE_APPLIED, action);
+          });
 
           success(obj);
         }, function(code, msg) {
@@ -802,8 +803,9 @@ function newClient(id) {
       self.getDataSet(dataset_id, function(dataset) {
         dataset.syncRunning = false;
         dataset.syncLoopEnd = new Date().getTime();
-        self.saveDataSet(dataset_id);
-        self.doNotify(dataset_id, dataset.hash, notification, status);
+        self.saveDataSet(dataset_id, function() {
+          self.doNotify(dataset_id, dataset.hash, notification, status);
+        });
       });
     },
 


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20023

# What
Fix intermittent issue where sync events are sent before the action be actually performed. It was faced where the client application was receiving SYNC_COMPLETE before the data be saved. The same unexpected behaviour shows occur with the event LOCAL_UPDATE_APPLIED too. 

# Why
The action is async and it is not waiting for the action to finish to send the event.

# How
Changing the implementation to send the event just after the action is performed. 

# Verification Steps
- Create a new sync project
- Use this pr to update fh-js-sdk and build a new www/lib.min.js 
- Update the client app www/lib.min.js
- Use the RHMAP preview to test it 
- Check if all times that a new item be added this item + the old ones will appear in the list
- Check if all times that a new item be updated this item with the new value + the old ones will be in the list

PS.: A POC with the steps to verify is added in the JIRA. 

## Checklist:
- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
