### PR TITLE
task(CVE-2017-18214): RHMAP-20719 - Remove moment dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog - fh-sync-js lib
+
+## 1.3.1 - 2018-06-12
+- CVE-2017-18214 : Remove unused moment dependency
+- Add Changelog

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "grunt-text-replace": "0.3.12",
     "grunt-zip": "0.12.0",
     "mocha": "1.17.1",
-    "moment": "^2.18.1",
     "rimraf": "2.6.1",
     "sinon": "1.9.0",
     "sinon-chai": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Javascript client for fh-sync offline synchronization library",
   "main": "src/index.js",
   "types": "./fh-sync-js.d.ts",


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20719

## WHAT
- Remove moment dependency from dev dependencies because it is not used.
- Add changelog file

## WHY
* Solve vulnerability. For further information check: https://nvd.nist.gov/vuln/detail/CVE-2017-18214
* Dep not used

## USAGE
No usage, it was declared in the dev deps. 

## STEPS TO TEST
* Run `grunt` tasks and/or check if the CI/Travis in PR was succeeded

