### PR TITLE
feat(Sync-IOS12) : Change in the Storage Adapter in order to allow it works with IOS 12 webkit update (RHMAP-22114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - fh-sync-js lib
 
+
+## 1.4.0 - 2019-04-15
+## Change
+- Change in the Storage Adapter in order to allow it works with IOS 12 webkit update. (IOS 12 still not supported by RHMAP) 
+
 ## 1.3.2 - 2018-09-27
 ## Fix
 - Fix intermittent issue where sync events are sent before the action be actually performed.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Javascript client for fh-sync offline synchronization library",
   "main": "src/index.js",
   "types": "./fh-sync-js.d.ts",


### PR DESCRIPTION
## Motivation:
https://issues.jboss.org/browse/RHMAP-22114

## What
* https://github.com/feedhenry/fh-sync-js/pull/48

## Why
Help to attend the user needs
