### PR TITLE
Indexdb open error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - fh-sync-js lib
 
+## 1.4.1 - 2019-11-07
+## Change
+- Emit an error if it takes too long to open index-db.
 
 ## 1.4.0 - 2019-04-15
 ## Change

--- a/example/index.html
+++ b/example/index.html
@@ -5,7 +5,7 @@
     crossorigin="anonymous"></script>
   <!-- TODO improve example to use local distribution build !-->
   <script src="../dist/fh-sync.js" type="text/javascript"></script>
-  <script src="./sync.js" type="text/javascript"></script>
+  <script src="./example/sync.js" type="text/javascript"></script>
 </head>
 <body>
 Messages will be printed to console.

--- a/example/sync.js
+++ b/example/sync.js
@@ -6,7 +6,7 @@ $fh.sync.init({
     "cloudUrl": "http://localhost:3000",
     "sync_frequency": 10,
     "do_console_log": true,
-    "storage_strategy": "dom"
+    "storage_strategy": "indexed-db"
 });
 
 //provide listeners for notifications.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync-js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Javascript client for fh-sync offline synchronization library",
   "main": "src/index.js",
   "types": "./fh-sync-js.d.ts",

--- a/src/sync-client.js
+++ b/src/sync-client.js
@@ -974,9 +974,11 @@ function newClient(id) {
     },
     
     getStorageAdapter: function (dataset_id, isSave, cb) {
-      var onFail = function(msg, err){
-        var errMsg = (isSave?'save to': 'load from' ) + ' local storage failed msg: ' + msg + ' err: ' + err;
-        self.doNotify(dataset_id, null, self.notifications.CLIENT_STORAGE_FAILED, errMsg);
+      var onFail = function(err){
+        err = err || new Error('storage error');
+        var msg = err.message || err;
+        var errMsg = (isSave?'save to': 'load from' ) + ' local storage failed msg: ' + msg;
+        self.doNotify(dataset_id, null, self.notifications.CLIENT_STORAGE_FAILED, msg);
         self.consoleLog(errMsg);
       };
      


### PR DESCRIPTION
At the moment, there seems to be a bug  in Safari on iOS 13 (13.1) that will cause the request to open indexdb to hang after Safari is moved from background to foreground. The `readyState` of the `IDBRequest` is stuck in `pending`, and none of the `onsuccess` or `onerror` event listeners are getting fired.

There have been a few issues reported that seem to be related to the issue:

https://bugs.webkit.org/show_bug.cgi?id=197050
https://bugs.webkit.org/show_bug.cgi?id=202705

However, until a fix is release by Apple, there isn't a whole lot we can do. The sync client does try to open a new db connection every time when it tries to save data. There is no cached/reused db connection at all in the sync client. 

However, given that in most of the cases, the open db request should be finished very quickly (within a second), we can check the state of the `IDBRequest` after a period of time (2 seconds for example). If for some reason the `readyState` is not `done`, we can assume the open db request has failed, and invoke the error handler. 